### PR TITLE
Add consent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Plugin uses sensible defaults prioritizing user experience & privacy:
 - use image tracking fallback for `noscript`
 - don't load anything when visitor has Do Not Track enabled
 - don't load anything in non-production environments
+- consent mode for privacy
 - allow loading tracking script locally
 - dev mode for local development
 
@@ -51,13 +52,14 @@ _NOTE: By default, this plugin only generates output when run in production mode
 
 ## Options
 
-Option        | Explanation
---------------|---------
-`siteId`      | Your Matomo site ID configured in your Matomo installation.
-`matomoUrl`   | The url of your Matomo installation.
-`siteUrl`     | The url of your site, usually the same as `siteMetadata.siteUrl`. Only used for generating the url for `noscript` image tracking fallback.
-`localScript` | (optional) Set path to load local `piwik.js` script, instead of loading it from your `matomoUrl`.
-`dev`         | (optional) Activate dev mode by setting to `true`. Will load all scripts despite not running in `production` environment. Ignores your local browser's DNT header too. Outputs some information in console about what it is doing. Useful for local testing but careful: all hits will be send like in production.
+Option           | Explanation
+-----------------|---------
+`siteId`         | Your Matomo site ID configured in your Matomo installation.
+`matomoUrl`      | The url of your Matomo installation.
+`siteUrl`        | The url of your site, usually the same as `siteMetadata.siteUrl`. Only used for generating the url for `noscript` image tracking fallback.
+`requireConsent` | (optional) If true, tracking will be disabled until you call `window._paq.push(['setConsentGiven']);`
+`localScript`    | (optional) Set path to load local `piwik.js` script, instead of loading it from your `matomoUrl`.
+`dev`            | (optional) Activate dev mode by setting to `true`. Will load all scripts despite not running in `production` environment. Ignores your local browser's DNT header too. Outputs some information in console about what it is doing. Useful for local testing but careful: all hits will be send like in production.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Option           | Explanation
 `siteId`         | Your Matomo site ID configured in your Matomo installation.
 `matomoUrl`      | The url of your Matomo installation.
 `siteUrl`        | The url of your site, usually the same as `siteMetadata.siteUrl`. Only used for generating the url for `noscript` image tracking fallback.
-`requireConsent` | (optional) If true, tracking will be disabled until you call `window._paq.push(['setConsentGiven']);`
+`requireConsent` | (optional) If true, tracking will be disabled until you call `window._paq.push(['setConsentGiven']);`.
+`disableCookies` | (optional) If true, no cookie will be used by Matomo.
 `localScript`    | (optional) Set path to load local `piwik.js` script, instead of loading it from your `matomoUrl`.
 `dev`            | (optional) Activate dev mode by setting to `true`. Will load all scripts despite not running in `production` environment. Ignores your local browser's DNT header too. Outputs some information in console about what it is doing. Useful for local testing but careful: all hits will be send like in production.
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -10,6 +10,7 @@ function buildTrackingCode(pluginOptions) {
     if (window.dev === true || !(navigator.doNotTrack == '1' || window.doNotTrack == '1')) {
       window._paq = window._paq || [];
       ${pluginOptions.requireConsent ? 'window._paq.push([\'requireConsent\']);' : ''}
+      ${pluginOptions.disableCookies ? 'window._paq.push([\'disableCookies\']);' : ''}
       window._paq.push(['setTrackerUrl', '${pluginOptions.matomoUrl}/piwik.php']);
       window._paq.push(['setSiteId', '${pluginOptions.siteId}']);
       window._paq.push(['trackPageView']);

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -9,6 +9,7 @@ function buildTrackingCode(pluginOptions) {
     window.dev = ${pluginOptions.dev}
     if (window.dev === true || !(navigator.doNotTrack == '1' || window.doNotTrack == '1')) {
       window._paq = window._paq || [];
+      ${pluginOptions.requireConsent ? 'window._paq.push([\'requireConsent\']);' : ''}
       window._paq.push(['setTrackerUrl', '${pluginOptions.matomoUrl}/piwik.php']);
       window._paq.push(['setSiteId', '${pluginOptions.siteId}']);
       window._paq.push(['trackPageView']);


### PR DESCRIPTION
Add an option to enable consent requirement. The developer has to call `window._paq.push(['setConsentGiven']);` to enable tracking.