### PR TITLE
Path exclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,30 @@ Option           | Explanation
 `siteId`         | Your Matomo site ID configured in your Matomo installation.
 `matomoUrl`      | The url of your Matomo installation.
 `siteUrl`        | The url of your site, usually the same as `siteMetadata.siteUrl`. Only used for generating the url for `noscript` image tracking fallback.
+`exclude`        | (optional) Specify an array of pathnames where tracking code will be excluded. The pathname `/offline-plugin-app-shell-fallback/` is excluded by default.
 `requireConsent` | (optional) If true, tracking will be disabled until you call `window._paq.push(['setConsentGiven']);`.
 `disableCookies` | (optional) If true, no cookie will be used by Matomo.
-`localScript`    | (optional) Set path to load local `piwik.js` script, instead of loading it from your `matomoUrl`.
+`localScript`    | (optional) If set, load local `piwik.js` script from the given path, instead of loading it from your `matomoUrl`.
 `dev`            | (optional) Activate dev mode by setting to `true`. Will load all scripts despite not running in `production` environment. Ignores your local browser's DNT header too. Outputs some information in console about what it is doing. Useful for local testing but careful: all hits will be send like in production.
+
+```js
+plugins: [
+  {
+    resolve: 'gatsby-plugin-matomo',
+    options: {
+      siteId: 'YOUR_SITE_ID',
+      matomoUrl: 'https://YOUR_MATOMO_URL.COM',
+      siteUrl: 'https://YOUR_LIVE_SITE_URL.COM'
+      // All the optional settings
+      exclude: ['/offline-plugin-app-shell-fallback/'],
+      requireConsent: false,
+      disableCookies: false,
+      localScript: '/piwik.js',
+      dev: false
+    }
+  }
+]
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
+[![gatsby-plugin-matomo](https://raw.githubusercontent.com/kremalicious/gatsby-plugin-matomo/master/gatsby-plugin-matomo.png)](https://kremalicious.com/gatsby-plugin-matomo/)
+
 # gatsby-plugin-matomo
 
-![gatsby-plugin-matomo](https://raw.githubusercontent.com/kremalicious/gatsby-plugin-matomo/master/gatsby-plugin-matomo.png)
 [![npm package](https://img.shields.io/npm/v/gatsby-plugin-matomo.svg)](https://www.npmjs.com/package/gatsby-plugin-matomo)
 [![Build Status](https://travis-ci.com/kremalicious/gatsby-plugin-matomo.svg?branch=master)](https://travis-ci.com/kremalicious/gatsby-plugin-matomo)
 [![Maintainability](https://api.codeclimate.com/v1/badges/067339a02f2058f5ba01/maintainability)](https://codeclimate.com/github/kremalicious/gatsby-plugin-matomo/maintainability)
 [![Greenkeeper badge](https://badges.greenkeeper.io/kremalicious/gatsby-plugin-matomo.svg)](https://greenkeeper.io/)
 
-⚛️📄🚀 Gatsby plugin to add [Matomo](https://matomo.org) (formerly Piwik) onto a site. Release post: https://kremalicious.com/gatsby-plugin-matomo/
+🥂 Gatsby plugin to add Matomo (formerly Piwik) onto a site. https://kremalicious.com/gatsby-plugin-matomo/
 
 ## Features
 
@@ -20,6 +21,7 @@ Plugin uses sensible defaults prioritizing user experience & privacy:
 - don't load anything in non-production environments
 - consent mode for privacy
 - allow loading tracking script locally
+- define paths to be excluded from tracking
 - dev mode for local development
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Matthias Kretschmann <m@kretschmann.io>",
   "scripts": {
     "build": "babel src --out-dir . --ignore __tests__",
-    "watch": "babel -w src --out-dir . --ignore __tests__",
+    "start": "babel -w src --out-dir . --ignore __tests__",
     "test": "eslint ./src/**/*.js",
     "release": "npm run changelog && ./node_modules/release-it/bin/release-it.js --src.tagName='v%s' --github.release --npm.publish --non-interactive",
     "release-minor": "npm run changelog && ./node_modules/release-it/bin/release-it.js minor --src.tagName='v%s' --github.release --npm.publish --non-interactive",
@@ -15,8 +15,8 @@
   },
   "dependencies": {
     "babel-runtime": "^6.26.0",
-    "react": "^16.4.2",
-    "react-hot-loader": "^4.3.4"
+    "react": "^16.6.3",
+    "react-hot-loader": "^4.3.12"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -7,7 +7,7 @@ function buildTrackingCode(pluginOptions) {
 
   const html = `
     window.dev = ${pluginOptions.dev}
-    if (window.dev === true || !(navigator.doNotTrack == '1' || window.doNotTrack == '1')) {
+    if (window.dev === true || !(navigator.doNotTrack === '1' || window.doNotTrack === '1')) {
       window._paq = window._paq || [];
       ${pluginOptions.requireConsent ? 'window._paq.push([\'requireConsent\']);' : ''}
       ${pluginOptions.disableCookies ? 'window._paq.push([\'disableCookies\']);' : ''}
@@ -50,11 +50,24 @@ function buildTrackingCodeNoJs(pluginOptions, pathname) {
 }
 
 exports.onRenderBody = ({ setPostBodyComponents, pathname }, pluginOptions) => {
-  if (process.env.NODE_ENV === 'production' || pluginOptions.dev === true) {
-    return setPostBodyComponents([
-      buildTrackingCode(pluginOptions),
-      buildTrackingCodeNoJs(pluginOptions, pathname)
-    ])
+  let excludePaths = ['/offline-plugin-app-shell-fallback/']
+
+  if (typeof pluginOptions.exclude !== 'undefined') {
+    pluginOptions.exclude.map(exclude => {
+      excludePaths.push(exclude)
+    })
+  }
+
+  const isPathExcluded = excludePaths.some(path => pathname === path)
+
+  if (
+    (process.env.NODE_ENV === 'production' || pluginOptions.dev === true) &&
+    !isPathExcluded
+  ) {
+      return setPostBodyComponents([
+        buildTrackingCode(pluginOptions),
+        buildTrackingCodeNoJs(pluginOptions, pathname)
+      ])
   }
   return null
 }


### PR DESCRIPTION
Add ability to exclude paths from being tracked. Excludes `/offline-plugin-app-shell-fallback/` by default.