### PR TITLE
Fix missing tracking code in rendered HTML

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -85,13 +85,10 @@ exports.onRenderBody = (
     (process.env.NODE_ENV === 'production' || pluginOptions.dev === true) &&
     !isPathExcluded
   ) {
-    return (
-      setHeadComponents([buildHead(pluginOptions)]) &&
-      setPostBodyComponents([
-        buildTrackingCode(pluginOptions),
-        buildTrackingCodeNoJs(pluginOptions, pathname)
-      ])
-    )
+    setHeadComponents([buildHead(pluginOptions)])
+    setPostBodyComponents([
+      buildTrackingCode(pluginOptions),
+      buildTrackingCodeNoJs(pluginOptions, pathname)
+    ])
   }
-  return null
 }


### PR DESCRIPTION
`onRenderBody` does take any return type, I removed the useless `return null` at the end of this function.
`setHeadComponents` doesn't return anything so the right side of the `&&` wasn't executed, only the `head` was built.