### PR TITLE
Add trackAllContentImpressions to record/enable content tracking

### DIFF
--- a/src/gatsby-browser.js
+++ b/src/gatsby-browser.js
@@ -37,6 +37,7 @@ exports.onRouteUpdate = ({ location, prevLocation }) => {
       _paq.push(['setDocumentTitle', title])
       _paq.push(['trackPageView'])
       _paq.push(['enableLinkTracking'])
+      _paq.push(['trackAllContentImpressions'])
 
       if (dev) {
         console.log(`[Matomo] Page view for: ${url} - ${title}`)


### PR DESCRIPTION
Thank you for this plugin!

This PR adds `_paq.push(['trackAllContentImpressions']);` after `trackPageView` to record content impressions on the new page.

More details at https://developer.matomo.org/guides/content-tracking