### PR TITLE
Add support for custom JS and PHP script names

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ plugins: [
       siteUrl: 'https://YOUR_LIVE_SITE_URL.COM',
       // All the optional settings
       matomoPhpScript: 'piwik.php',
-      mataomoJsScript: 'piwik.js',
+      matomoJsScript: 'piwik.js',
       exclude: ['/offline-plugin-app-shell-fallback/'],
       requireConsent: false,
       disableCookies: false,

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ _NOTE: By default, this plugin only generates output when run in production mode
 | `siteId`         | Your Matomo site ID configured in your Matomo installation.                                                                                                                                                                                                                                                        |
 | `matomoUrl`      | The url of your Matomo installation.                                                                                                                                                                                                                                                                               |
 | `siteUrl`        | The url of your site, usually the same as `siteMetadata.siteUrl`. Only used for generating the url for `noscript` image tracking fallback.                                                                                                                                                                         |
+| `matomoPhpScript`| (optional) The name of your Matomo PHP script. Defaults to `piwik.php`                                                                                                                                                                                                                                                                 |
+| `matomoJsScript` | (optional) The name of your Matomo JS script. Defaults to `piwik.js`                                                                                                                                                                                                                                                                  |
 | `exclude`        | (optional) Specify an array of pathnames where tracking code will be excluded. The pathname `/offline-plugin-app-shell-fallback/` is excluded by default.                                                                                                                                                          |
 | `requireConsent` | (optional) If true, tracking will be disabled until you call `window._paq.push(['setConsentGiven']);`.                                                                                                                                                                                                             |
 | `disableCookies` | (optional) If true, no cookie will be used by Matomo.                                                                                                                                                                                                                                                              |
@@ -86,6 +88,8 @@ plugins: [
       matomoUrl: 'https://YOUR_MATOMO_URL.COM',
       siteUrl: 'https://YOUR_LIVE_SITE_URL.COM',
       // All the optional settings
+      matomoPhpScript: 'piwik.php',
+      mataomoJsScript: 'piwik.js',
       exclude: ['/offline-plugin-app-shell-fallback/'],
       requireConsent: false,
       disableCookies: false,

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -53,7 +53,7 @@ function buildTrackingCode(pluginOptions) {
 }
 
 function buildTrackingCodeNoJs(pluginOptions, pathname) {
-  const { matomoUrl, siteId, siteUrl } = pluginOptions
+  const { matomoUrl, matomoPhpScript = 'piwik.php', siteId, siteUrl } = pluginOptions
   const html = `<img src="${matomoUrl}/${matomoPhpScript}?idsite=${siteId}&rec=1&url=${siteUrl +
     pathname}" style="border:0" alt="tracker" />`
 

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -4,6 +4,8 @@ import React from 'react'
 function buildTrackingCode(pluginOptions) {
   const {
     matomoUrl,
+    matomoPhpScript = 'piwik.php',
+    matomoJsScript = 'piwik.js',
     siteId,
     dev,
     localScript,
@@ -12,7 +14,7 @@ function buildTrackingCode(pluginOptions) {
     cookieDomain
   } = pluginOptions
 
-  const script = localScript ? localScript : `${matomoUrl}/piwik.js`
+  const script = localScript ? localScript : `${matomoUrl}/${matomoJsScript}`
 
   const html = `
     window.dev = ${dev}
@@ -21,11 +23,11 @@ function buildTrackingCode(pluginOptions) {
       ${requireConsent ? "window._paq.push(['requireConsent']);" : ''}
       ${disableCookies ? "window._paq.push(['disableCookies']);" : ''}
       ${
-        cookieDomain
-          ? `window._paq.push(['setCookieDomain', '${cookieDomain}']);`
-          : ''
-      }
-      window._paq.push(['setTrackerUrl', '${matomoUrl}/piwik.php']);
+    cookieDomain
+      ? `window._paq.push(['setCookieDomain', '${cookieDomain}']);`
+      : ''
+    }
+      window._paq.push(['setTrackerUrl', '${matomoUrl}/${matomoPhpScript}']);
       window._paq.push(['setSiteId', '${siteId}']);
       window._paq.push(['enableHeartBeatTimer']);
       window.start = new Date();
@@ -52,7 +54,7 @@ function buildTrackingCode(pluginOptions) {
 
 function buildTrackingCodeNoJs(pluginOptions, pathname) {
   const { matomoUrl, siteId, siteUrl } = pluginOptions
-  const html = `<img src="${matomoUrl}/piwik.php?idsite=${siteId}&rec=1&url=${siteUrl +
+  const html = `<img src="${matomoUrl}/${matomoPhpScript}?idsite=${siteId}&rec=1&url=${siteUrl +
     pathname}" style="border:0" alt="tracker" />`
 
   return (


### PR DESCRIPTION
Adds the ability to optionally specify the names for the JS and PHP scripts (i.e. `matomo.js` and `matomo.php` instead of `piwik.js` and `piwik.php`).