### PR TITLE
Add cookie consent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _NOTE: By default, this plugin only generates output when run in production mode
 | `matomoJsScript`  | (optional) The name of your Matomo JS script. Defaults to `piwik.js`                                                                                                                                                                                                                                               |
 | `exclude`         | (optional) Specify an array of pathnames where tracking code will be excluded. The pathname `/offline-plugin-app-shell-fallback/` is excluded by default.                                                                                                                                                          |
 | `requireConsent`  | (optional) If true, tracking will be disabled until you call `window._paq.push(['setConsentGiven']);`.                                                                                                                                                                                                             |
+| `requireCookieConsent`  | (optional) If true, no cookies will be stored or used until you call `window._paq.push(['setCookieConsentGiven']);`.                                                                                                                                                                                                             |
 | `disableCookies`  | (optional) If true, no cookie will be used by Matomo.                                                                                                                                                                                                                                                              |
 | `cookieDomain`    | (optional) Specify cookie domain.                                                                                                                                                                                                                                                                                  |
 | `localScript`     | (optional) If set, load local `piwik.js` script from the given path, instead of loading it from your `matomoUrl`.                                                                                                                                                                                                  |
@@ -93,6 +94,7 @@ plugins: [
       matomoJsScript: 'piwik.js',
       exclude: ['/offline-plugin-app-shell-fallback/'],
       requireConsent: false,
+      requireCookieConsent: false,
       disableCookies: false,
       cookieDomain: '*.example.org',
       localScript: '/piwik.js',

--- a/src/__tests__/gatsby-ssr.js
+++ b/src/__tests__/gatsby-ssr.js
@@ -77,6 +77,14 @@ describe('gatsby-plugin-google-analytics', () => {
           expect(result).toMatch(/requireConsent/)
         })
 
+        it('sets requireCookieConsent', () => {
+          const { setPostBodyComponents } = setup({
+            requireCookieConsent: true
+          })
+          const result = JSON.stringify(setPostBodyComponents.mock.calls[0][0])
+          expect(result).toMatch(/requireCookieConsent/)
+        })
+
         it('sets disableCookies', () => {
           const { setPostBodyComponents } = setup({
             disableCookies: true

--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -10,6 +10,7 @@ function buildTrackingCode(pluginOptions) {
     dev,
     localScript,
     requireConsent,
+    requireCookieConsent,
     disableCookies,
     cookieDomain
   } = pluginOptions
@@ -21,6 +22,7 @@ function buildTrackingCode(pluginOptions) {
     if (window.dev === true || !(navigator.doNotTrack === '1' || window.doNotTrack === '1')) {
       window._paq = window._paq || [];
       ${requireConsent ? "window._paq.push(['requireConsent']);" : ''}
+      ${requireCookieConsent ? "window._paq.push(['requireCookieConsent']);" : ''}
       ${disableCookies ? "window._paq.push(['disableCookies']);" : ''}
       ${
         cookieDomain


### PR DESCRIPTION
Added the cookie consent option, so Matomo only stores or uses cookies after `window._paq.push(['setCookieConsentGiven']);` has been called. Very similar to the "requireConsent" option, but it directly allows tracking and only needs consent for cookies.