### PR TITLE
Standard Matomo tracking code

### DIFF
--- a/src/gatsby-ssr.js
+++ b/src/gatsby-ssr.js
@@ -26,7 +26,7 @@ function buildTrackingCode(pluginOptions) {
   const html = `
     window.dev = ${dev}
     if (window.dev === true || ${dntCondition}) {
-      window._paq = window._paq || [];
+      var _paq = window._paq = window._paq || [];
       ${requireConsent ? "window._paq.push(['requireConsent']);" : ''}
       ${
         requireCookieConsent


### PR DESCRIPTION
Thanks for making this plugin!

I have been in discussion with the Matomo support team about an issue we've been experiencing and they've noticed that

>the _paq variable is declared differently to the standard implementation. The standard implementation is: `var _paq = window._paq = window._paq || [];`. While in itself this shouldn't necessarily cause issues, when you have anything on your pages that directly call _paq.push - it may result in some strange behaviour.

The Matomo tracking code [documentation](https://developer.matomo.org/guides/tracking-javascript-guide) also recommends the above described implementation.

Hope this helps

